### PR TITLE
chore: bump to v1.0.0 shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This project is now **inactive**.  It exists only as a thin shim that
 depends on the official [TA-Lib](https://pypi.org/project/TA-Lib/)
 Python package.
 
-Installing this package will simply install the upstream
-`TA-Lib` distribution:
+Older pre-built wheels have been yanked from PyPI to reduce accidental
+installs.  Starting with version 1.0.0, this package acts purely as a
+wrapper to install the upstream `TA-Lib` distribution:
 
 ```bash
 pip install ta-lib-everywhere

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ta-lib-everywhere"
-version = "0.6.6"
+version = "1.0.0"
 description = "Shim package that installs the official TA-Lib package."
 readme = "README.md"
 license = {text = "BSD-2-Clause"}


### PR DESCRIPTION
## Summary
- bump project version to 1.0.0
- document that older wheels were yanked and package acts as shim to TA-Lib

## Testing
- `pip wheel .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_e_68a06ce47fd083228c06f6c255acafc9